### PR TITLE
Add main menu with dropdown preact component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,6 @@ module.exports = {
   snapshotSerializers: ['preact-render-spy/snapshot'],
   transform: jestPreset.transform,
   testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', 'd.ts$'],
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.[jt]sx?$',
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: { '\\.module\\.(c|sc|sa)ss$': 'identity-obj-proxy' },
   setupFiles: ['jest-plugin-context/setup'],
+  snapshotSerializers: ['preact-render-spy/snapshot'],
   transform: jestPreset.transform,
   testEnvironment: 'jsdom',
   testRegex: '(/(test|__tests__)/(?!_).*|(\\.|/)(test|spec))\\.[jt]sx?$',

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "dependencies": {
     "@marp-team/marp-core": "^0.0.12",
+    "detect-browser": "^3.0.1",
     "incremental-dom": "^0.5.1",
     "markdown-it-incremental-dom": "^2.0.1",
     "preact": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-sass": "^4.9.3",
     "npm-run-all": "^4.1.3",
     "postcss-loader": "^3.0.0",
+    "preact-render-spy": "^1.3.0",
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
     "sass-loader": "^7.1.0",

--- a/src/components/button.module.scss
+++ b/src/components/button.module.scss
@@ -13,6 +13,7 @@
 
 .button {
   @include button-color(#fff, #eee);
+  @include remove-focus-ring;
 
   appearance: none;
   border-radius: 3px;
@@ -24,7 +25,6 @@
   display: inline-block;
   font-size: $base-font-size;
   margin: 0;
-  outline: 0;
   padding: ($base-font-size / 2) $base-font-size;
   position: relative;
   text-align: left;

--- a/src/components/button.module.scss
+++ b/src/components/button.module.scss
@@ -31,6 +31,11 @@
   transition: box-shadow 0.1s linear;
   white-space: nowrap;
 
+  &,
+  &:active {
+    color: inherit;
+  }
+
   &:focus {
     box-shadow: 0 0 0 2px rgba($brand-primary, 0.5), 0 3px 6px rgba(#000, 0.2);
   }

--- a/src/components/button.module.scss
+++ b/src/components/button.module.scss
@@ -32,7 +32,7 @@
   white-space: nowrap;
 
   &:focus {
-    box-shadow: 0 0 0 2px rgba(#69c, 0.5), 0 3px 6px rgba(#000, 0.2);
+    box-shadow: 0 0 0 2px rgba($brand-primary, 0.5), 0 3px 6px rgba(#000, 0.2);
   }
 }
 

--- a/src/components/button.module.scss
+++ b/src/components/button.module.scss
@@ -1,5 +1,3 @@
-@import '../../style/variables';
-
 @mixin button-color($base, $border, $highlight: #000) {
   background-color: $base;
   border-color: $border;

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -4,12 +4,10 @@ import { combineClass } from './utils'
 
 const { h } = preact
 
-export const Button = props => (
-  <button {...props} class={combineClass(props, style.button)} />
-)
+export const Button = props => <button {...combineClass(props, style.button)} />
 
 export const withClass = (klass: string, Target = Button) => props => (
-  <Target {...props} class={combineClass(props, style[klass])} />
+  <Target {...combineClass(props, style[klass])} />
 )
 
 export const HeaderButton = withClass('header')

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -1,21 +1,15 @@
-// tslint:disable:variable-name
 import * as preact from 'preact'
 import style from './button.module.scss'
+import { combineClass } from './utils'
 
 const { h } = preact
 
 export const Button = props => (
-  <button
-    {...props}
-    class={`${props.class || props.className} ${style.button}`}
-  />
+  <button {...props} class={combineClass(props, style.button)} />
 )
 
 export const withClass = (klass: string, Target = Button) => props => (
-  <Target
-    {...props}
-    class={`${props.class || props.className} ${style[klass]}`}
-  />
+  <Target {...props} class={combineClass(props, style[klass])} />
 )
 
 export const HeaderButton = withClass('header')

--- a/src/components/dropdown.module.scss
+++ b/src/components/dropdown.module.scss
@@ -1,0 +1,61 @@
+$dropdown-gap-vertical: $base-font-size / 2;
+$dropdown-gap-horizontal: $base-font-size;
+
+.dropdown {
+  position: relative;
+
+  &-hit {
+    display: inline;
+    display: contents;
+    pointer-events: none;
+
+    * {
+      pointer-events: auto;
+    }
+  }
+}
+
+.menu {
+  background-color: #fff;
+  border: 1px solid #eee;
+  box-shadow: 0 2px 2px rgba(#000, 0.15);
+  display: block;
+  left: 0;
+  list-style: none;
+  margin: 0;
+  padding: $dropdown-gap-vertical 0;
+  position: absolute;
+  top: 100%;
+}
+
+.item {
+  display: block;
+
+  &-button {
+    appearance: none;
+    background-color: #fff;
+    border: 0;
+    display: block;
+    font-size: $base-font-size;
+    line-height: $base-font-size;
+    outline: 0;
+    padding: $dropdown-gap-vertical $dropdown-gap-horizontal;
+    text-align: left;
+    white-space: nowrap;
+    width: 100%;
+
+    &:focus,
+    &:hover {
+      background-color: mix(#000, #fff, 5%);
+
+      &:active {
+        background-color: mix(#000, #fff, 10%);
+      }
+    }
+  }
+}
+
+.divider {
+  border-top: 1px solid #eee;
+  margin: $dropdown-gap-vertical 0;
+}

--- a/src/components/dropdown.module.scss
+++ b/src/components/dropdown.module.scss
@@ -38,6 +38,11 @@ $dropdown-gap-horizontal: $base-font-size;
     white-space: nowrap;
     width: 100%;
 
+    &,
+    &:active {
+      color: inherit;
+    }
+
     &:focus,
     &:hover {
       background-color: mix(#000, #fff, 5%);

--- a/src/components/dropdown.module.scss
+++ b/src/components/dropdown.module.scss
@@ -3,19 +3,11 @@ $dropdown-gap-horizontal: $base-font-size;
 
 .dropdown {
   position: relative;
-
-  &-hit {
-    display: inline;
-    display: contents;
-    pointer-events: none;
-
-    * {
-      pointer-events: auto;
-    }
-  }
 }
 
 .menu {
+  @include remove-focus-ring;
+
   background-color: #fff;
   border: 1px solid #eee;
   box-shadow: 0 2px 2px rgba(#000, 0.15);
@@ -32,15 +24,17 @@ $dropdown-gap-horizontal: $base-font-size;
   display: block;
 
   &-button {
+    @include remove-focus-ring;
+
     appearance: none;
     background-color: #fff;
     border: 0;
     display: block;
     font-size: $base-font-size;
     line-height: $base-font-size;
-    outline: 0;
     padding: $dropdown-gap-vertical $dropdown-gap-horizontal;
     text-align: left;
+    user-select: none;
     white-space: nowrap;
     width: 100%;
 

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -1,0 +1,96 @@
+import * as preact from 'preact'
+import style from './dropdown.module.scss'
+import { combineClass, combineEvent } from './utils'
+
+const { Component, h } = preact
+
+export interface DropdownProps {
+  children: any[]
+}
+
+export interface DropdownStates {
+  open: boolean
+}
+
+export class Dropdown extends Component<DropdownProps, DropdownStates> {
+  private readonly contents: any[]
+  private readonly menu: any
+
+  constructor(props: DropdownProps) {
+    super(props)
+
+    this.state = { open: false }
+    this.contents = [...props.children]
+
+    // Extract DropdownMenu from children
+    const menuIdx = this.contents.findIndex(
+      elm => typeof elm === 'object' && elm.nodeName === DropdownMenu
+    )
+    this.menu = menuIdx === -1 ? undefined : this.contents.splice(menuIdx, 1)[0]
+  }
+
+  getChildContext() {
+    return { dropdown: this }
+  }
+
+  close() {
+    this.setState({ open: false })
+  }
+
+  open() {
+    this.setState({ open: true })
+  }
+
+  toggle() {
+    this.setState({ open: !this.state.open })
+  }
+
+  render(_, state: DropdownStates) {
+    const { open } = state
+
+    return (
+      <span class={style.dropdown}>
+        <span class={style.dropdownHit} onClick={() => this.toggle()}>
+          {this.contents}
+        </span>
+        {open && this.menu}
+      </span>
+    )
+  }
+}
+
+export class DropdownMenu extends Component<{}, {}> {
+  render(props) {
+    return <ul role="menu" {...props} class={combineClass(props, style.menu)} />
+  }
+}
+
+export function DropdownItem(this: any, props) {
+  const { onClick } = props
+
+  return (
+    <li role="menuitem" class={style.item}>
+      <button
+        {...props}
+        class={combineClass(props, style.itemButton)}
+        onClick={(...args) => {
+          this.context.dropdown.close()
+
+          if (typeof onClick === 'function') {
+            const callback = () => onClick(...args)
+
+            if ((window as any).requestIdleCallback) {
+              ;(window as any).requestIdleCallback(callback)
+            } else {
+              setTimeout(callback, 0)
+            }
+          }
+        }}
+      />
+    </li>
+  )
+}
+
+export const DropdownDivider = () => (
+  <li role="separator" class={style.divider} />
+)

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -52,8 +52,7 @@ export class Dropdown extends Component<any, { open: boolean }> {
   render(props) {
     return (
       <div
-        {...props}
-        class={style.dropdown}
+        {...combineClass(props, style.dropdown)}
         ref={div => (this.container = div)}
         onFocusOut={e => this.handleFocusOut(e)}
       />
@@ -64,12 +63,7 @@ export class Dropdown extends Component<any, { open: boolean }> {
 export function DropdownMenu(this, props: { children: any }) {
   return (
     this.context.dropdownOpen && (
-      <ul
-        role="menu"
-        tabIndex={-1}
-        {...props}
-        class={combineClass(props, style.menu)}
-      />
+      <ul role="menu" tabIndex={-1} {...combineClass(props, style.menu)} />
     )
   )
 }
@@ -81,21 +75,13 @@ export function DropdownItem(
   const { onClick } = props
   const handleClick = () => {
     this.context.dropdown.close()
-
-    if (typeof onClick === 'function') {
-      if ((window as any).requestIdleCallback) {
-        ;(window as any).requestIdleCallback(() => onClick())
-      } else {
-        setTimeout(() => onClick(), 0)
-      }
-    }
+    if (typeof onClick === 'function') setTimeout(() => onClick(), 16)
   }
 
   return (
     <li role="menuitem" class={style.item}>
       <button
-        {...props}
-        class={combineClass(props, style.itemButton)}
+        {...combineClass(props, style.itemButton)}
         onClick={handleClick}
       />
     </li>

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -6,6 +6,7 @@ const { Component, h } = preact
 
 export class Dropdown extends Component<any, { open: boolean }> {
   private container?: HTMLDivElement
+  private mouseDownButton?: Element
 
   constructor(props) {
     super(props)
@@ -28,10 +29,24 @@ export class Dropdown extends Component<any, { open: boolean }> {
     this.setState({ open: !from })
   }
 
-  handleFocusOut(e) {
-    this.setState({
-      open: this.container ? this.container.contains(e.relatedTarget) : false,
-    })
+  handleButtonClick(e) {
+    this.toggle()
+
+    // Keep focus to button after clicking in macOS Firefox and Safari
+    // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+    e.target.focus()
+  }
+
+  handleButtonMouseDown(e) {
+    this.mouseDownButton = e.target
+    setTimeout(() => (this.mouseDownButton = undefined), 0)
+  }
+
+  private handleFocusOut(e) {
+    if (!this.mouseDownButton)
+      this.setState({
+        open: this.container ? this.container.contains(e.relatedTarget) : false,
+      })
   }
 
   render(props) {

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -1,6 +1,6 @@
 import * as preact from 'preact'
 import style from './dropdown.module.scss'
-import { combineClass, combineEvent } from './utils'
+import { combineClass } from './utils'
 
 const { Component, h } = preact
 

--- a/src/components/header.module.scss
+++ b/src/components/header.module.scss
@@ -10,3 +10,9 @@
   background-repeat: no-repeat;
   background-position: center;
 }
+
+@media print {
+  .header {
+    display: none;
+  }
+}

--- a/src/components/header.module.scss
+++ b/src/components/header.module.scss
@@ -4,7 +4,7 @@
   height: 50px;
 }
 
-.menu-button {
+.app-button {
   background-image: url('../../style/assets/marp.svg');
   background-size: 30px 30px;
   background-repeat: no-repeat;

--- a/src/components/header.module.scss
+++ b/src/components/header.module.scss
@@ -1,5 +1,3 @@
-@import '../../style/variables';
-
 .header {
   display: flex;
   box-sizing: border-box;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,7 +21,7 @@ export default () => {
     <header class={style.header}>
       <Dropdown ref={elm => (mainMenu = elm)}>
         <HeaderButton
-          class={style.menuButton}
+          class={style.appButton}
           onClick={e => mainMenu.handleButtonClick(e)}
           onMouseDown={e => mainMenu.handleButtonMouseDown(e)}
         />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,7 +22,8 @@ export default () => {
       <Dropdown ref={elm => (mainMenu = elm)}>
         <HeaderButton
           class={style.menuButton}
-          onClick={() => mainMenu.toggle()}
+          onClick={e => mainMenu.handleButtonClick(e)}
+          onMouseDown={e => mainMenu.handleButtonMouseDown(e)}
         />
         <DropdownMenu>
           <DropdownItem>New</DropdownItem>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,12 +1,27 @@
-// tslint:disable:variable-name
 import * as preact from 'preact'
-import { Button, HeaderButton } from './button'
+import { HeaderButton } from './button'
+import {
+  Dropdown,
+  DropdownMenu,
+  DropdownItem,
+  DropdownDivider,
+} from './dropdown'
 import style from './header.module.scss'
 
 const { h } = preact
 
 export default () => (
   <header class={style.header}>
-    <HeaderButton class={style.menuButton} />
+    <Dropdown>
+      <HeaderButton class={style.menuButton} />
+      <DropdownMenu>
+        <DropdownItem>New</DropdownItem>
+        <DropdownDivider />
+        <DropdownItem>Open...</DropdownItem>
+        <DropdownItem>Save</DropdownItem>
+        <DropdownDivider />
+        <DropdownItem>Print / Export to PDF</DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
   </header>
 )

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,3 @@
-import { detect } from 'detect-browser'
 import * as preact from 'preact'
 import { HeaderButton } from './button'
 import {
@@ -7,12 +6,10 @@ import {
   DropdownItem,
   DropdownDivider,
 } from './dropdown'
+import { isChrome } from './utils'
 import style from './header.module.scss'
 
 const { h } = preact
-
-const detected = detect()
-const isChrome = detected && detected.name === 'chrome'
 
 export default () => {
   let mainMenu: Dropdown
@@ -33,7 +30,7 @@ export default () => {
           <DropdownDivider />
           <DropdownItem onClick={() => window.print()}>
             Print
-            {isChrome && ' / Export to PDF'}
+            {isChrome() && ' / Export to PDF'}
             ...
           </DropdownItem>
         </DropdownMenu>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,3 +1,4 @@
+import { detect } from 'detect-browser'
 import * as preact from 'preact'
 import { HeaderButton } from './button'
 import {
@@ -9,6 +10,9 @@ import {
 import style from './header.module.scss'
 
 const { h } = preact
+
+const detected = detect()
+const isChrome = detected && detected.name === 'chrome'
 
 export default () => {
   let mainMenu: Dropdown
@@ -27,7 +31,9 @@ export default () => {
           <DropdownItem>Save</DropdownItem>
           <DropdownDivider />
           <DropdownItem onClick={() => window.print()}>
-            Print / Export to PDF
+            Print
+            {isChrome && ' / Export to PDF'}
+            ...
           </DropdownItem>
         </DropdownMenu>
       </Dropdown>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,18 +10,27 @@ import style from './header.module.scss'
 
 const { h } = preact
 
-export default () => (
-  <header class={style.header}>
-    <Dropdown>
-      <HeaderButton class={style.menuButton} />
-      <DropdownMenu>
-        <DropdownItem>New</DropdownItem>
-        <DropdownDivider />
-        <DropdownItem>Open...</DropdownItem>
-        <DropdownItem>Save</DropdownItem>
-        <DropdownDivider />
-        <DropdownItem>Print / Export to PDF</DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
-  </header>
-)
+export default () => {
+  let mainMenu: Dropdown
+
+  return (
+    <header class={style.header}>
+      <Dropdown ref={elm => (mainMenu = elm)}>
+        <HeaderButton
+          class={style.menuButton}
+          onClick={() => mainMenu.toggle()}
+        />
+        <DropdownMenu>
+          <DropdownItem>New</DropdownItem>
+          <DropdownDivider />
+          <DropdownItem>Open...</DropdownItem>
+          <DropdownItem>Save</DropdownItem>
+          <DropdownDivider />
+          <DropdownItem onClick={() => window.print()}>
+            Print / Export to PDF
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    </header>
+  )
+}

--- a/src/components/tslint.json
+++ b/src/components/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "variable-name": false
+  }
+}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,3 @@
+export function combineClass(from, ...classes: string[]) {
+  return [from.class || from.className, ...classes].filter(k => k).join(' ')
+}

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -3,7 +3,13 @@ import { detect } from 'detect-browser'
 const browser = detect()
 
 export function combineClass(from, ...classes: string[]) {
-  return [from.class || from.className, ...classes].filter(k => k).join(' ')
+  const combined = {
+    ...from,
+    class: [from.className || from.class, ...classes].filter(k => k).join(' '),
+  }
+
+  delete combined.className
+  return combined
 }
 
 export function isChrome() {

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,3 +1,11 @@
+import { detect } from 'detect-browser'
+
+const browser = detect()
+
 export function combineClass(from, ...classes: string[]) {
   return [from.class || from.className, ...classes].filter(k => k).join(' ')
+}
+
+export function isChrome() {
+  return browser && browser.name === 'chrome'
 }

--- a/style/_initialization.scss
+++ b/style/_initialization.scss
@@ -1,0 +1,2 @@
+@import './variables';
+@import './mixin';

--- a/style/_mixin.scss
+++ b/style/_mixin.scss
@@ -1,0 +1,10 @@
+@mixin remove-focus-ring {
+  &,
+  &:focus {
+    outline: 0;
+  }
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
+}

--- a/style/_mixin.scss
+++ b/style/_mixin.scss
@@ -1,10 +1,11 @@
 @mixin remove-focus-ring {
-  &,
-  &:focus {
-    outline: 0;
-  }
+  outline: 0;
 
   &::-moz-focus-inner {
     border: 0;
+  }
+
+  &:focus {
+    outline: 0;
   }
 }

--- a/style/_variables.scss
+++ b/style/_variables.scss
@@ -1,1 +1,7 @@
+// Brand colors
+$brand-primary: #0288d1;
+$brand-secondary: #67b8e3;
+$brand-dark: #02669d;
+
+// Base style
 $base-font-size: 16px;

--- a/style/index.scss
+++ b/style/index.scss
@@ -1,4 +1,4 @@
-@import './variables';
+@import './initialization';
 
 @media print {
   .marp {

--- a/test/components/dropdown.tsx
+++ b/test/components/dropdown.tsx
@@ -1,0 +1,143 @@
+import { h } from 'preact'
+import { deep, RenderContext, FindWrapper } from 'preact-render-spy'
+import {
+  Dropdown,
+  DropdownMenu,
+  DropdownItem,
+} from '../../src/components/dropdown'
+import style from '../../src/components/dropdown.module.scss'
+
+jest.useFakeTimers()
+
+describe('Dropdown components', () => {
+  const dropdown = (props = {}, itemProps = {}) =>
+    deep(
+      <Dropdown {...props}>
+        <DropdownMenu>
+          <DropdownItem {...itemProps}>test</DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    )
+
+  describe('<Dropdown />', () => {
+    it('renders <div> with dropdown class', () => {
+      expect(dropdown().find(<div class={style.dropdown} />)).toHaveLength(1)
+    })
+
+    context('with rest props', () => {
+      // React compatible className
+      const component = dropdown({ className: 'test', title: 'test' })
+
+      it('keeps passed rest props', () => {
+        const div: FindWrapper<any, any> = component.find(<div title="test" />)
+
+        expect(div).toHaveLength(1)
+        expect(div.attr('class')).toContain('test')
+        expect(div.attr('class')).toContain(style.dropdown)
+      })
+    })
+
+    context('when onFocusOut is triggered by children of dropdown', () => {
+      let component: RenderContext<any, any>
+
+      beforeEach(() => (component = dropdown({ id: 'test-children' })))
+
+      const onFocusOut = (relatedTarget: Element | null) =>
+        component
+          .find(<div id="test-children" />)
+          .simulate('focusOut', { relatedTarget })
+
+      it('closes dropdown with focused to <body>', () => {
+        component.setState({ open: true })
+        onFocusOut(document.body)
+
+        expect(component.state('open')).toBe(false)
+      })
+
+      it('opens dropdown with focused to dropdown menu', () => {
+        component.setState({ open: true })
+        const container = component.component().container
+
+        // The container of menu item
+        onFocusOut(container.querySelector('ul[role="menu"]'))
+        expect(component.state('open')).toBe(true)
+
+        // Menu item
+        onFocusOut(container.querySelector('li'))
+        expect(component.state('open')).toBe(true)
+      })
+
+      it('closes dropdown when the focused element is null', () => {
+        component.setState({ open: true })
+        onFocusOut(null)
+
+        expect(component.state('open')).toBe(false)
+      })
+    })
+
+    describe('Instance methods', () => {
+      const component = dropdown()
+      const instance: Dropdown = component.component()
+
+      it('opens and closes dropdown menu by #open and #close', () => {
+        const findMenu = () => component.find(<ul role="menu" />)
+        expect(findMenu()).toHaveLength(0)
+
+        instance.open()
+        component.rerender()
+        expect(findMenu()).toHaveLength(1)
+
+        instance.close()
+        component.rerender()
+        expect(findMenu()).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('DropdownItem', () => {
+    const item = (
+      props = {}
+    ): {
+      dropdownParent: FindWrapper<any, any>
+      dropdownItem: FindWrapper<any, any>
+    } => {
+      const dropdownParent = dropdown({}, props)
+      dropdownParent.setState({ open: true })
+
+      return {
+        dropdownParent,
+        dropdownItem: dropdownParent.find(<DropdownItem>test</DropdownItem>),
+      }
+    }
+
+    it('renders <button /> with passed rest props', () => {
+      const { dropdownItem } = item({ title: 'button' })
+      const button: FindWrapper<any, any> = dropdownItem.find('button')
+
+      expect(button).toHaveLength(1)
+      expect(button.attr('title')).toBe('button')
+    })
+
+    context('with clicked button', () => {
+      it('closes dropdown menu', () => {
+        const { dropdownParent, dropdownItem } = item()
+        dropdownItem.find('button').simulate('click')
+
+        expect(dropdownParent.state('open')).toBe(false)
+      })
+
+      context('when onClick event is attached', () => {
+        it('triggers attached event with delayed by timer', () => {
+          const onClick = jest.fn()
+          const { dropdownItem } = item({ onClick })
+          dropdownItem.find('button').simulate('click')
+
+          expect(setTimeout).toBeCalledTimes(1)
+          jest.runOnlyPendingTimers()
+
+          expect(onClick).toBeCalled()
+        })
+      })
+    })
+  })
+})

--- a/test/components/header.tsx
+++ b/test/components/header.tsx
@@ -1,7 +1,10 @@
 import { h } from 'preact'
-import { deep } from 'preact-render-spy'
+import { deep, FindWrapper } from 'preact-render-spy'
 import { HeaderButton } from '../../src/components/button'
 import Header from '../../src/components/header'
+import * as utils from '../../src/components/utils'
+
+afterEach(() => jest.restoreAllMocks())
 
 describe('<Header />', () => {
   const header = (props = {}) => deep(<Header {...props} />)
@@ -10,8 +13,16 @@ describe('<Header />', () => {
     expect(header().find('header')).toHaveLength(1))
 
   describe('App button', () => {
-    const appBtn = (component = header()) =>
+    const appBtn = (component: FindWrapper<any, any> = header()) =>
       component.find(<HeaderButton class="appButton" />)
+
+    const clickEventSpy = (props = {}) => ({
+      target: { focus: jest.fn() },
+      ...props,
+    })
+
+    const click = (btn: FindWrapper<any, any>, e = clickEventSpy()) =>
+      btn.simulate('click', e)
 
     it('renders a header button with appButton class', () =>
       expect(appBtn()).toHaveLength(1))
@@ -20,19 +31,65 @@ describe('<Header />', () => {
       it('toggles main menu and focuses to the clicked button', () => {
         const component = header()
         const findMenu = () => component.find(<ul role="menu" />)
-        const target = { focus: jest.fn() }
+        const e = clickEventSpy()
 
         expect(findMenu()).toHaveLength(0)
 
         // Open
-        appBtn(component).simulate('click', { target })
+        click(appBtn(component), e)
         expect(findMenu()).toHaveLength(1)
-        expect(target.focus).toBeCalledTimes(1)
+        expect(e.target.focus).toBeCalledTimes(1)
 
         // Close
-        appBtn(component).simulate('click', { target })
+        click(appBtn(component), e)
         expect(findMenu()).toHaveLength(0)
-        expect(target.focus).toBeCalledTimes(2)
+        expect(e.target.focus).toBeCalledTimes(2)
+      })
+    })
+
+    describe('Menu items', () => {
+      const component = (): FindWrapper<any, any> => {
+        const ret = header()
+        click(appBtn(ret))
+
+        return ret
+      }
+
+      const findMenuItem = (
+        from: FindWrapper<any, any>,
+        condition: (element: FindWrapper<any, any>) => any
+      ): FindWrapper<any, any> =>
+        from
+          .find('DropdownItem')
+          .map(e => e)
+          .find(condition)
+
+      describe('Print', () => {
+        it('has a <DropdownItem> for print', () => {
+          const print = findMenuItem(
+            component(),
+            elm => elm.text() === 'Print...'
+          )
+          expect(print).toHaveLength(1)
+
+          // Trigger window.print() on click
+          const printSpy = jest.spyOn(window, 'print').mockImplementation()
+          print.simulate('click')
+          expect(printSpy).toBeCalled()
+        })
+
+        context('when it has rendered in Chrome', () => {
+          beforeEach(() =>
+            jest.spyOn(utils, 'isChrome').mockImplementation(() => true))
+
+          it('has a <DropdownItem> for print and export to PDF', () => {
+            const print = findMenuItem(
+              component(),
+              elm => elm.text() === 'Print / Export to PDF...'
+            )
+            expect(print).toHaveLength(1)
+          })
+        })
       })
     })
   })

--- a/test/components/header.tsx
+++ b/test/components/header.tsx
@@ -1,0 +1,39 @@
+import { h } from 'preact'
+import { deep } from 'preact-render-spy'
+import { HeaderButton } from '../../src/components/button'
+import Header from '../../src/components/header'
+
+describe('<Header />', () => {
+  const header = (props = {}) => deep(<Header {...props} />)
+
+  it('renders <header> element', () =>
+    expect(header().find('header')).toHaveLength(1))
+
+  describe('App button', () => {
+    const appBtn = (component = header()) =>
+      component.find(<HeaderButton class="appButton" />)
+
+    it('renders a header button with appButton class', () =>
+      expect(appBtn()).toHaveLength(1))
+
+    context('when clicked', () => {
+      it('toggles main menu and focuses to the clicked button', () => {
+        const component = header()
+        const findMenu = () => component.find(<ul role="menu" />)
+        const target = { focus: jest.fn() }
+
+        expect(findMenu()).toHaveLength(0)
+
+        // Open
+        appBtn(component).simulate('click', { target })
+        expect(findMenu()).toHaveLength(1)
+        expect(target.focus).toBeCalledTimes(1)
+
+        // Close
+        appBtn(component).simulate('click', { target })
+        expect(findMenu()).toHaveLength(0)
+        expect(target.focus).toBeCalledTimes(2)
+      })
+    })
+  })
+})

--- a/test/typings.d.ts
+++ b/test/typings.d.ts
@@ -1,0 +1,6 @@
+declare module '*.module.scss' {
+  const cssModule: {
+    [className: string]: string
+  }
+  export default cssModule
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,13 @@ module.exports = env => {
       },
     },
     'postcss-loader',
-    'sass-loader',
+    {
+      loader: 'sass-loader',
+      options: {
+        data: modules && '@import "variables";',
+        includePaths: [path.join(__dirname, 'style')],
+      },
+    },
   ]
 
   return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = env => {
     {
       loader: 'sass-loader',
       options: {
-        data: modules && '@import "variables";',
+        data: modules && '@import "initialization";',
         includePaths: [path.join(__dirname, 'style')],
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,6 +5301,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
@@ -6148,6 +6153,16 @@ object-visit@^1.0.0:
   integrity sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
   dependencies:
     isobject "^3.0.0"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  integrity sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -7009,6 +7024,22 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.2, postcss@^7.0.5:
     source-map "^0.6.1"
     supports-color "^5.5.0"
 
+preact-render-spy@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/preact-render-spy/-/preact-render-spy-1.3.0.tgz#f64b83f4de33d9696e69e5b08c4ae5e29decd6d1"
+  integrity sha512-6gdi9mCMlhNPv4JRoQNSKu2kEbhStfJT/bN+n3gb/NwGKNmFg9q8eac9qFTSCswsOWmkdDk2WJiUoHZImIPSyA==
+  dependencies:
+    lodash.isequal "^4.5.0"
+    object.entries "^1.0.4"
+    preact-render-to-string "^3.6.3"
+
+preact-render-to-string@^3.6.3:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.8.2.tgz#bd72964d705a57da3a9e72098acaa073dd3ceff9"
+  integrity sha512-przuZPajiurStGgxMoJP0EJeC4xj5CgHv+M7GfF3YxAdhGgEWAkhOSE0xympAFN20uMayntBZpttIZqqLl77fw==
+  dependencies:
+    pretty-format "^3.5.1"
+
 preact@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.3.1.tgz#ed34f79d09edc5efd32a378a3416ef5dc531e3ac"
@@ -7041,6 +7072,11 @@ pretty-format@^23.6.0:
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
+
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,6 +2681,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-browser@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-3.0.1.tgz#39beead014347a8a2be1f3c4cb30a0aef2127c44"
+  integrity sha512-L6b76EfUxnoxGHM5Vz7nrshQPIbOHtitDWpGufrp5srQdJrEYi1xpUVZeFbfssWAJvUWo/iDIVlz8hOP4Z8OCw==
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"


### PR DESCRIPTION
This PR will add the `Dropdown` preact components to implement main menu that it can expand from Marp app button.

![main-menu](https://user-images.githubusercontent.com/3993388/47513928-3afd5e00-d8ba-11e8-976d-793e19e3fe00.png)

### ToDo

- [x] Fill the component tests