### PR TITLE
Persist text buffer to localStorage by using unissist

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "markdown-it-incremental-dom": "^2.1.0",
     "preact": "^8.4.2",
     "preact-context": "^1.1.2",
+    "unissist": "^1.3.0",
     "unistore": "^3.2.1",
     "uuid": "^3.3.2"
   }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,4 +1,6 @@
 import * as preact from 'preact'
+import persistStore from 'unissist'
+import localStorageAdapter from 'unissist/integrations/localStorageAdapter'
 import createStore, { Store } from 'unistore'
 import devtools from 'unistore/devtools'
 import { Provider } from 'unistore/preact'
@@ -10,16 +12,19 @@ const { h } = preact
 
 export interface GlobalStore {
   buffer: string
+  bufferChanged: boolean
 }
 
 // Global store
 const store: Store<GlobalStore> = (() => {
-  const initialStore: Store<GlobalStore> = createStore({
-    buffer: '',
+  let store = createStore({ buffer: '', bufferChanged: false })
+
+  persistStore(store, localStorageAdapter(), {
+    map: ({ buffer, bufferChanged }) => ({ buffer, bufferChanged }),
   })
 
-  if (process.env.NODE_ENV === 'development') return devtools(initialStore)
-  return initialStore
+  if (process.env.NODE_ENV === 'development') store = devtools(store)
+  return store
 })()
 
 export default () => {

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -2,50 +2,24 @@ import * as preact from 'preact'
 import style from './style/editor.module.scss'
 import { combineClass } from './utils'
 
-const { Component, h } = preact
+const { h } = preact
 
 export interface EditorProps {
+  value: string
   onInput?: JSX.EventHandler<Event>
-  value?: string
   [key: string]: any
 }
 
-export interface EditorStates {
-  value: string
-}
+const Editor: preact.FunctionalComponent<EditorProps> = props => (
+  <textarea {...combineClass(props, style.editor)} onInput={props.onInput}>
+    {props.value}
+  </textarea>
+)
 
-export default class Editor extends Component<EditorProps, EditorStates> {
-  static defaultProps = {
-    value: '',
-  }
-
-  constructor(props) {
-    super(props)
-    this.state = { value: props.value }
-  }
-
-  handleInput = (e: any) => {
-    const { onInput } = this.props
-    this.setState({ value: e.target.value }, () => onInput && onInput(e))
-  }
-
-  render() {
-    return (
-      <textarea
-        {...combineClass(this.props, style.editor)}
-        onInput={this.handleInput}
-        value={this.state.value}
-      >
-        {/* Prevent moving caret unexpectedly in Microsoft Edge
-         * https://github.com/developit/preact/issues/326#issuecomment-375513643 */}
-        {this.state.value}
-      </textarea>
-    )
-  }
-}
-
-export const MarpEditor = props => (
+export const MarpEditor: preact.FunctionalComponent<EditorProps> = props => (
   <div class={style.marpEditorContainer}>
     <Editor {...combineClass(props, style.marpEditor)} />
   </div>
 )
+
+export default Editor

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -8,7 +8,7 @@ const { h } = preact
 
 export const Preview: preact.FunctionalComponent<{
   buffer: string
-  handleInput: Function
+  handleInput: JSX.EventHandler<Event>
 }> = ({ buffer, handleInput }) => (
   <div class={style.preview}>
     <MarpEditor value={buffer} onInput={handleInput} />
@@ -19,6 +19,6 @@ export const Preview: preact.FunctionalComponent<{
 export default connect<any, {}, any, any>(
   'buffer',
   () => ({
-    handleInput: (_, e) => ({ buffer: e.target.value }),
+    handleInput: (_, e) => ({ buffer: e.target.value, bufferChanged: true }),
   })
 )(Preview)

--- a/test/components/preview.tsx
+++ b/test/components/preview.tsx
@@ -13,7 +13,7 @@ describe('<Preview />', () => {
   const preview = (props: any = {}) => deep(<Preview buffer="" {...props} />)
 
   it('renders <MarpEditor>', () =>
-    expect(preview().find(<MarpEditor />)).toHaveLength(1))
+    expect(preview().find(<MarpEditor value="" />)).toHaveLength(1))
 
   it('renders <MarpPreview>', () =>
     expect(preview().find(<MarpPreview />)).toHaveLength(1))
@@ -27,7 +27,7 @@ describe('<Preview />', () => {
 
   context('when text has inputed to textarea', () => {
     const textarea = (cmp: FindWrapper<any, any>): FindWrapper<any, any> =>
-      cmp.find(<MarpEditor />).find('textarea')
+      cmp.find(<MarpEditor value="" />).find('textarea')
 
     it('calls handleInput action', () => {
       const handleInput = jest.fn()

--- a/yarn.lock
+++ b/yarn.lock
@@ -9500,6 +9500,11 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
+unissist@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/unissist/-/unissist-1.3.0.tgz#0a39a94c061d4fbfca4e3974b0b1210223c2d02a"
+  integrity sha512-IFC+63jummISCfgy/3hFH6N2wV7CmwHKafTt2/uO3a9k2ueTT6nB0i0mpE1CeIfTUdUPSk96sXSP4tCnnPJv/Q==
+
 unist-util-find-all-after@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz#9be49cfbae5ca1566b27536670a92836bf2f8d6d"


### PR DESCRIPTION
By using [unissist](https://github.com/DonnieWest/unissist), we will persist editting text buffer to `localStorage`.

Marp Web cannot handle file in Web environment completely, so we treat Web as a single buffer. Instead, the buffer could be changed by opening file from `Open` menu.